### PR TITLE
15 grepping with cpe can result in confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ packages_matched: 2
 ➜  echo $?
 1
 ```
+
+#### extract data using user-defined output
+```sh
+sbomgr packages -O 'toolv,tooln,pkgn,pkgv' ~/tmp/app.spdx.json 
+2.0.88	Microsoft.SBOMTool	Coordinated Packages                 	229170
+2.0.88	Microsoft.SBOMTool	chalk                                	2.4.2
+2.0.88	Microsoft.SBOMTool	async-settle                         	1.0.0
+```
+
 # Search flags 
 
 ## Packages 
@@ -146,17 +155,17 @@ all of these match criteria are exclusive to each other.
 - `-j` or `--jsonl` outputs the search results in [jsonl](https://jsonlines.org/).
 - `-p` or `--print-errors` includes errors encoundered during searching. Default is to ignore them. 
 - `-O` or `--output-format` user-defined output format. Options are listed below 
- - `filen` - filepath
- - `tooln` - tool with which sbom was generated, only prints the first one
- - `toolv` - tool version
- - `docn`  - sbom document name
- - `docv`  - sbom document version
- - `cpe`   - package cpe, only prints the first one, indicates how many cpe's exists.
- - `purl`  - package purl
- - `pkgn`  - package name 
- - `pkgv`  - package version
- - `pkgl`  - package licenses
- - `specn` - spec of the sbom document, spdx or cdx. 
+  - `filen` - filepath
+  - `tooln` - tool with which sbom was generated, only prints the first one
+  - `toolv` - tool version
+  - `docn`  - sbom document name
+  - `docv`  - sbom document version
+  - `cpe`   - package cpe, only prints the first one, indicates how many cpe's exists.
+  - `purl`  - package purl
+  - `pkgn`  - package name 
+  - `pkgv`  - package version
+  - `pkgl`  - package licenses
+  - `specn` - spec of the sbom document, spdx or cdx. 
 
 #### *Stats Control*
 ----

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ all of these match criteria are exclusive to each other.
 - `--no-filename` removes the filename from the output. 
 - `-j` or `--jsonl` outputs the search results in [jsonl](https://jsonlines.org/).
 - `-p` or `--print-errors` includes errors encoundered during searching. Default is to ignore them. 
+- `-O` or `--output-format` user-defined output format. Options are listed below 
+ - `filen` - filepath
+ - `tooln` - tool with which sbom was generated, only prints the first one
+ - `toolv` - tool version
+ - `docn`  - sbom document name
+ - `docv`  - sbom document version
+ - `cpe`   - package cpe, only prints the first one, indicates how many cpe's exists.
+ - `purl`  - package purl
+ - `pkgn`  - package name 
+ - `pkgv`  - package version
+ - `pkgl`  - package licenses
+ - `specn` - spec of the sbom document, spdx or cdx. 
 
 #### *Stats Control*
 ----

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -87,7 +87,7 @@ func init() {
 	packagesCmd.Flags().StringP("checksum", "H", "", "filter packages by checksum")
 	packagesCmd.MarkFlagsMutuallyExclusive("cpe", "purl", "name", "checksum")
 
-	packagesCmd.Flags().StringP("output-format", "O", "", "user-defined output format, comma separated list of columns. <link> ")
+	packagesCmd.Flags().StringP("output-format", "O", "", "user-defined output format, comma separated list of columns. https://github.com/interlynk-io/sbomgr#output-control ")
 }
 
 func validatePath(path string) error {

--- a/pkg/search/cdx/results.go
+++ b/pkg/search/cdx/results.go
@@ -34,7 +34,7 @@ func (doc *cdxDoc) constructResults(pIndices []int) (*results.Result, error) {
 		docVersion = doc.doc.Metadata.Component.Version
 	}
 
-	return &results.Result{
+	result := &results.Result{
 		Path:           doc.ro.CurrentPath,
 		Format:         string(doc.ro.SbomFileFormat),
 		Spec:           string(doc.ro.SbomSpecType),
@@ -43,7 +43,15 @@ func (doc *cdxDoc) constructResults(pIndices []int) (*results.Result, error) {
 		Packages:       doc.pkgResults(pIndices),
 		Files:          []results.File{},
 		Matched:        len(pIndices) > 0,
-	}, nil
+	}
+
+	if doc.doc.Metadata != nil && doc.doc.Metadata.Tools != nil {
+		tools := *doc.doc.Metadata.Tools
+		result.ToolName = tools[0].Name
+		result.ToolVersion = tools[0].Version
+	}
+
+	return result, nil
 }
 
 func (doc *cdxDoc) pkgResults(pIndices []int) []results.Package {
@@ -56,6 +64,7 @@ func (doc *cdxDoc) pkgResults(pIndices []int) []results.Package {
 			Name:    comp.Name,
 			Version: comp.Version,
 			PURL:    comp.PackageURL,
+			CPE:     []string{comp.CPE},
 		}
 
 		if doc.opts.DoLicense() {

--- a/pkg/search/params.go
+++ b/pkg/search/params.go
@@ -37,6 +37,7 @@ type SearchParams struct {
 	Filename    bool
 	Json        bool
 	PrintErrors bool
+	Formats     []string
 
 	//stats Control
 	Count bool
@@ -139,4 +140,8 @@ func (s *SearchParams) SearchPURL() string {
 
 func (s *SearchParams) SearchHash() string {
 	return s.Hash
+}
+
+func (s *SearchParams) HasOutputFormats() bool {
+	return len(s.Formats) > 0
 }

--- a/pkg/search/results/results.go
+++ b/pkg/search/results/results.go
@@ -39,7 +39,9 @@ type Result struct {
 	ProductVersion string    `json:"product_version,omitempty"`
 	Packages       []Package `json:"packages,omitempty"`
 	Files          []File    `json:"files,omitempty"`
-	Matched        bool      `json:"matched,omitempty"`
+	ToolName       string    `json:"tool_name,omitempty"`
+	ToolVersion    string    `json:"tool_version,omitempty"`
+	Matched        bool
 }
 
 func NewSearchResult(path, format, spec, err string) *Result {


### PR DESCRIPTION
Added user-defined output support, very similar to ps.  Below are the list of custom controls. usage example

```sh
sbomgr packages -O 'toolv,tooln,pkgn,pkgv' ~/tmp/app.spdx.json 
2.0.88	Microsoft.SBOMTool	Coordinated Packages                 	229170
2.0.88	Microsoft.SBOMTool	chalk                                	2.4.2
2.0.88	Microsoft.SBOMTool	async-settle                         	1.0.0
```

```
filen - filepath
tooln - tool with which sbom was generated, only prints the first one
toolv - tool version
docn - sbom document name
docv - sbom document version
cpe - package cpe, only prints the first one, indicates how many cpe's exists.
purl - package purl
pkgn - package name
pkgv - package version
pkgl - package licenses
specn - spec of the sbom document, spdx or cdx.
```
