### PR TITLE
22 bug column listing is not correct

### DIFF
--- a/pkg/search/cdx/results.go
+++ b/pkg/search/cdx/results.go
@@ -63,8 +63,14 @@ func (doc *cdxDoc) pkgResults(pIndices []int) []results.Package {
 		res := results.Package{
 			Name:    comp.Name,
 			Version: comp.Version,
-			PURL:    comp.PackageURL,
-			CPE:     []string{comp.CPE},
+		}
+
+		if len(comp.PackageURL) > 0 {
+			res.PURL = comp.PackageURL
+		}
+
+		if len(comp.CPE) > 0 {
+			res.CPE = []string{comp.CPE}
 		}
 
 		if doc.opts.DoLicense() {

--- a/pkg/search/output.go
+++ b/pkg/search/output.go
@@ -118,9 +118,15 @@ func outputBasic(r *results.Result, nr *SearchParams) (int, error) {
 					if len(pkg.CPE) > 0 {
 						cpef := fmt.Sprintf("%s[%d more]", pkg.CPE[0], len(pkg.CPE))
 						p = append(p, cpef)
+					} else {
+						p = append(p, "[NOCPE]")
 					}
 				case "purl":
-					p = append(p, pkg.PURL)
+					if len(pkg.PURL) > 0 {
+						p = append(p, pkg.PURL)
+					} else {
+						p = append(p, "[NOPURL]")
+					}
 				case "pkgn":
 					p = append(p, pkg.Name)
 				case "pkgv":

--- a/pkg/search/output.go
+++ b/pkg/search/output.go
@@ -107,13 +107,29 @@ func outputBasic(r *results.Result, nr *SearchParams) (int, error) {
 				case "filen":
 					p = append(p, r.Path)
 				case "tooln":
-					p = append(p, r.ToolName)
+					if len(r.ToolName) > 0 {
+						p = append(p, r.ToolName)
+					} else {
+						p = append(p, "[NOTOOL]")
+					}
 				case "toolv":
-					p = append(p, r.ToolVersion)
+					if len(r.ToolVersion) > 0 {
+						p = append(p, r.ToolVersion)
+					} else {
+						p = append(p, "[NOTOOLVER]")
+					}
 				case "docn":
-					p = append(p, r.ProductName)
+					if len(r.ProductName) > 0 {
+						p = append(p, r.ProductName)
+					} else {
+						p = append(p, "[NODOC]")
+					}
 				case "docv":
-					p = append(p, r.ProductVersion)
+					if len(r.ProductVersion) > 0 {
+						p = append(p, r.ProductVersion)
+					} else {
+						p = append(p, "[NODOCVER]")
+					}
 				case "cpe":
 					if len(pkg.CPE) > 0 {
 						cpef := fmt.Sprintf("%s[%d more]", pkg.CPE[0], len(pkg.CPE))
@@ -128,9 +144,17 @@ func outputBasic(r *results.Result, nr *SearchParams) (int, error) {
 						p = append(p, "[NOPURL]")
 					}
 				case "pkgn":
-					p = append(p, pkg.Name)
+					if len(pkg.Name) > 0 {
+						p = append(p, pkg.Name)
+					} else {
+						p = append(p, "[NOPKGNAME]")
+					}
 				case "pkgv":
-					p = append(p, pkg.Version)
+					if len(pkg.Version) > 0 {
+						p = append(p, pkg.Version)
+					} else {
+						p = append(p, "[NOPKGVER]")
+					}
 				case "pkgl":
 					var b []string
 					for _, l := range pkg.Licenses {

--- a/pkg/search/spdx/results.go
+++ b/pkg/search/spdx/results.go
@@ -59,9 +59,18 @@ func (s *spdxDoc) pkgResults(indices []int) []results.Package {
 		pkgs[i] = results.Package{
 			Name:    s.doc.Packages[idx].PackageName,
 			Version: s.doc.Packages[idx].PackageVersion,
-			PURL:    s.Purl(idx),
-			CPE:     s.CPEs(idx),
 		}
+
+		purls := s.Purl(idx)
+		if len(purls) > 0 {
+			pkgs[i].PURL = purls
+		}
+
+		cpes := s.CPEs(idx)
+		if len(cpes) > 0 {
+			pkgs[i].CPE = cpes
+		}
+
 		if s.opts.DoLicense() {
 			ls := s.licenses(idx)
 			for _, lic := range ls {


### PR DESCRIPTION
Fixed the issue. 

Output will look something like 

```
[NOTOOLVER]	trivy	gomod                                            	[NOPKGVER]                         		[NOCPE]	[NOPURL]
[NOTOOLVER]	trivy	gomod                                            	[NOPKGVER]                         		[NOCPE]	[NOPURL]
[NOTOOLVER]	trivy	github.com/opencontainers/image-spec             	1.1.0-rc2                          		[NOCPE]	pkg:golang/github.com/opencontainers/image-spec@1.1.0-rc2
[NOTOOLVER]	trivy	github.com/nozzle/throttler                      	0.0.0-20180817012639-2ea982251481  		[NOCPE]	pkg:golang/github.com/nozzle/throttler@0.0.0-20180817012639-2ea982251481
[NOTOOLVER]	trivy	github.com/sergi/go-diff                         	1.2.0                              		[NOCPE]	pkg:golang/github.com/sergi/go-diff@1.2.0
[NOTOOLVER]	trivy	github.com
```