### PR TITLE
Update scount strings to be user-friendly

### DIFF
--- a/pkg/search/output.go
+++ b/pkg/search/output.go
@@ -234,8 +234,8 @@ func handleFinalOutput(nr *SearchParams, matched []int, outputErrs []error) erro
 	}
 
 	if nr.DoCount() && (!nr.DoJson() || !nr.BeQuiet()) {
-		fmt.Printf("files_matched: %d\n", matchedSbomFilesCount)
-		fmt.Printf("packages_matched: %d\n", matchedItems)
+		fmt.Printf("Matching file count: %d\n", matchedSbomFilesCount)
+		fmt.Printf("Matching package count: %d\n", matchedItems)
 		return nil
 	}
 


### PR DESCRIPTION
Add userfriendly strings for count output, this has only be changed for tabular output. json output does not change 

Was
```
files_matched: 1
packages_matched: 4
```
Is
```
Matching file count: 1
Matching package count: 4
```
