### PR TITLE
Add checksum name & value

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ all of these match criteria are exclusive to each other.
   - `pkgv`  - package version
   - `pkgl`  - package licenses
   - `specn` - spec of the sbom document, spdx or cdx. 
+  - `chkn`  - checksum name
+  - `chkv`  - checksum value 
 
 #### *Stats Control*
 ----

--- a/pkg/search/cdx/results.go
+++ b/pkg/search/cdx/results.go
@@ -73,6 +73,15 @@ func (doc *cdxDoc) pkgResults(pIndices []int) []results.Package {
 			res.CPE = []string{comp.CPE}
 		}
 
+		if comp.Hashes != nil {
+			for _, c := range *comp.Hashes {
+				res.Checksums = append(res.Checksums, results.Checksum{
+					Algorithm: string(c.Algorithm),
+					Value:     string(c.Value),
+				})
+			}
+		}
+
 		if doc.opts.DoLicense() {
 			ls := doc.licenses(comp)
 			for _, lic := range ls {

--- a/pkg/search/results/results.go
+++ b/pkg/search/results/results.go
@@ -16,6 +16,11 @@ package results
 
 import "github.com/interlynk-io/sbomgr/pkg/licenses"
 
+type Checksum struct {
+	Algorithm string `json:"algorithm"`
+	Value     string `json:"value"`
+}
+
 type Package struct {
 	Name       string                  `json:"name"`
 	Version    string                  `json:"version"`
@@ -24,6 +29,7 @@ type Package struct {
 	Direct     bool                    `json:"direct,omitempty"`
 	PathToRoot []string                `json:"path_to_root,omitempty"`
 	Licenses   []licenses.LicenseStore `json:"license,omitempty"`
+	Checksums  []Checksum              `json:"checksum,omitempty"`
 }
 
 type File struct {

--- a/pkg/search/spdx/results.go
+++ b/pkg/search/spdx/results.go
@@ -71,6 +71,13 @@ func (s *spdxDoc) pkgResults(indices []int) []results.Package {
 			pkgs[i].CPE = cpes
 		}
 
+		for _, c := range s.doc.Packages[idx].PackageChecksums {
+			pkgs[i].Checksums = append(pkgs[i].Checksums, results.Checksum{
+				Algorithm: string(c.Algorithm),
+				Value:     string(c.Value),
+			})
+		}
+
 		if s.opts.DoLicense() {
 			ls := s.licenses(idx)
 			for _, lic := range ls {


### PR DESCRIPTION
Add support for checksum name and value. 

This feature prints out the name of the checksum and value, associated with packages. 

```
➜  ./build/sbomgr packages -O 'pkgn,pkgv,chkn,chkv' ~/data/redis-commander-sbom-cdx.json | head
fast-safe-stringify             2.0.7           SHA-512         52d9ba09dcd3fbac6c0e4da6f12eae2fc547c4dc08e89b9bf9ef4d6137009acdbc4fce294dadb9189415f63d02634375accf212b8c7a82ba45d8141ffb6ab054
supports-color                  7.2.0           SHA-512         aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047
semver                          6.3.0           SHA-512         6f7f5305a4d27d5eb206b6a953cf69e5f29e904da6fcdc270e870e56bb90152d7fbde320773b8f72738cdf833a0b0c56f231ff97111ae6b0680de530bb91c74f
punycode                        1.4.1           [NOCHKN]        [NOCHKV]                                                                                                                        
ioredis                         4.28.5          SHA-512         dc6628d0626d2ea80d5e3e1886b8ac2da34dbd648dc124b6c12e0e10b19f1b11fc23af7e5df35d9e657503237e66a321d22ede5fe4968ebc0528304381f042d4
helper-compilation-targets      7.19.3          SHA-512         eb9112a8b1b21a62ef811d26b2de40756d4590d963f6b42c08a76ecc4a043e10420c5197bf3da35ba6d7146ea2d3f32b576b3b8615e38dbdb203370fb9094bc2
node-releases                   2.0.6           SHA-512         3e25579cdb859b9fa26242c135eab9db5d61bcedfccbadd3d22d8a2a1d8a9d4b37469cc9f89b4e0c58e40fcca32f09c3913605d5e29785e53076cb11f8d45976
picocolors                      1.0.0           SHA-512         d5fca0ae84cb947bbaeb38b6e95a130eff324609b415c71e72cb2da3e321b19d03fc3196dac9bc13c0235bb354e5555346de46c5b799e6a06e26bf87c8b6248d
is-arguments                    1.1.0           SHA-512         d488f894e30f97fc41e640439fb23e6f6b6d3cc29af2cce1108ad70ee5d00ffa1edc724b4cb86a8601aca7083219de8c3b2c0152a56f622705ef69648039c81e
deep-eql                        3.0.1           SHA-512         f9078843237966e3bedd49390d887aff578a3b49b462624518d9851c6002a5fd4294bd679a557fa7880d81b976a491b18176f87daaa8e9413e33900210cc9573
```