### PR TITLE
Add support for direct deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,50 +26,62 @@
 ```sh
 go install github.com/interlynk-io/sbomgr@latest
 ```
+
 other installations [options](#installation)
 
 # SBOM Card
-[![SBOMCard](https://api.interlynk.io/api/v1/badges?type=hcard&project_group_id=e8e2ba0c-3d04-4a2e-9b37-dca774bd08bd
-)](https://app.interlynk.io/customer/products?id=e8e2ba0c-3d04-4a2e-9b37-dca774bd08bd&signed_url_params=eyJfcmFpbHMiOnsibWVzc2FnZSI6IklqSmtaakkyTkRRMUxXSTBaR0V0TkdJME9TMWhPVFpqTFRBd09UZGtZMlptTWpabU9TST0iLCJleHAiOm51bGwsInB1ciI6InNoYXJlX2x5bmsvc2hhcmVfbHluayJ9fQ==--6d74d14e40d6676522b1c529d44e4a320f05bcf3d42121e61e1275a1297a3453)
+
+[![SBOMCard](https://api.interlynk.io/api/v1/badges?type=hcard&project_group_id=e8e2ba0c-3d04-4a2e-9b37-dca774bd08bd)](https://app.interlynk.io/customer/products?id=e8e2ba0c-3d04-4a2e-9b37-dca774bd08bd&signed_url_params=eyJfcmFpbHMiOnsibWVzc2FnZSI6IklqSmtaakkyTkRRMUxXSTBaR0V0TkdJME9TMWhPVFpqTFRBd09UZGtZMlptTWpabU9TST0iLCJleHAiOm51bGwsInB1ciI6InNoYXJlX2x5bmsvc2hhcmVfbHluayJ9fQ==--6d74d14e40d6676522b1c529d44e4a320f05bcf3d42121e61e1275a1297a3453)
 
 # Basic usage
+
 Search for packages with exact name matching "abbrev".
+
 ```sh
 sbomgr packages -N 'abbrev' <sbom file or dir>
 ```
 
 Search for packages with regexp name matching "log4"
+
 ```sh
 sbomgr packages -EN 'log4' <sbom file or dir>
 ```
 
 Search for packages in air gapped environment for name matching "log4"
+
 ```sh
 export INTERLYNK_DISABLE_VERSION_CHECK=true sbomgr packages -EN 'log4' <sbom file or dir>
 ```
+
 # Features
+
 - SBOM format agnostic and currently supports searching through SPDX and CycloneDX.
 - Blazing Fast :rocket:
 - Output search results as [jsonl](https://jsonlines.org/).
 - Supports RE2 [regular expressions](https://github.com/google/re2/wiki/Syntax)
 
-
 # Use cases
+
 `sbomgr` can answer some of the most common SBOM use cases by searching an SBOM file or SBOM repository.
 
 #### How many SBOM and packages exist in the repository?
+
 ```sh
 ➜ sbomgr packages -c ~/data/sbom-repo/docker-images
 sbom_files_matched: 86
 packages_matched: 33556
 ```
+
 #### Are there packages with `zlib` in the name?
+
 ```sh
 ➜ sbomgr packages -cEN 'zlib' ~/data/sbom-repo/docker-images
 sbom_files_matched: 71
 packages_matched: 145
 ```
+
 #### Are there packages with a given checksum?
+
 ```sh
 ➜ sbomgr packages -c -H '5c260231de4f62ee26888776190b4c3fda6cbe14' ~/data/sbom-repo/docker-images
 sbom_files_matched: 2
@@ -77,6 +89,7 @@ packages_matched: 2
 ```
 
 #### Create a json report of packages with .zip files
+
 ```sh
 ➜ sbomgr packages -jrE -N '\.zip$' ~/data/ | jq .
 {
@@ -96,6 +109,7 @@ packages_matched: 2
 ```
 
 #### Create a json report of all licenses included in an sbom
+
 ```sh
 ➜ sbomgr packages -jl ~/data/some-sboms/julia.spdx | jq .
 {
@@ -116,8 +130,8 @@ packages_matched: 2
     },
 ```
 
-
 #### During CI check if a malicious package is present??
+
 ```sh
 ➜  sbomgr packages -qN 'abbrev' ~/tmp/app.spdx.json
 ➜  echo $?
@@ -128,21 +142,26 @@ packages_matched: 2
 ```
 
 #### extract data using user-defined output
+
 ```sh
 sbomgr packages -O 'toolv,tooln,pkgn,pkgv' ~/tmp/app.spdx.json
 2.0.88	Microsoft.SBOMTool	Coordinated Packages                 	229170
 2.0.88	Microsoft.SBOMTool	chalk                                	2.4.2
 2.0.88	Microsoft.SBOMTool	async-settle                         	1.0.0
 ```
+
 #### Using containerized sbomgr
 
 ```sh
 $docker run [volume-maps] ghcr.io/interlynk-io/sbomgr [command] [options]
 ```
+
 Example
+
 ```sh
 $docker run -v ~/interlynk/sbomlc/:/app/sbomlc ghcr.io/interlynk-io/sbomgr packages -c /app/sbomlc
 ```
+
 ```
 Unable to find image 'ghcr.io/interlynk-io/sbomgr:latest' locally
 latest: Pulling from interlynk-io/sbomgr
@@ -160,11 +179,14 @@ Matching package count: 716953
 # Search flags
 
 ## Packages
+
 This section explains the flags relevant to the packages search feature.
 The packages search takes only a single argument, either a file or a directory. There are man flags which can be specified to control its behaviour.
 
-#### *Match Criteria*
+#### _Match Criteria_
+
 ---
+
 - `-N` or `--name` used for package/component name search.
 - `-C` or `--cpe` used for package/component cpe search.
 - `-P` or `--purl` used for pacakge/component purl search.
@@ -172,16 +194,22 @@ The packages search takes only a single argument, either a file or a directory. 
 
 all of these match criteria are exclusive to each other.
 
-#### *Patter Matching*
----------
+#### _Patter Matching_
+
+---
+
 - `-E` or `--extended-regexp` flag can be used to indicate if the match criteria is a regular expression. Syntax supported is https://github.com/google/re2/wiki/Syntax.
 
-#### *Matching Control*
------
+#### _Matching Control_
+
+---
+
 - `-i` or `--ignore-case` case insensitive matching.
 
-#### *Output Control*
-----
+#### _Output Control_
+
+---
+
 - `-l` or `--license` this includes the license of the package/component in the output.
 - `-q` or `--quiet` this suppresses all output of the tool, the return value of the tool is 0 indicating success, if it finds the search criteria.
 - `--no-filename` removes the filename from the output.
@@ -191,32 +219,40 @@ all of these match criteria are exclusive to each other.
   - `filen` - filepath
   - `tooln` - tool with which sbom was generated, only prints the first one
   - `toolv` - tool version
-  - `docn`  - sbom document name
-  - `docv`  - sbom document version
-  - `cpe`   - package cpe, only prints the first one, indicates how many cpe's exists.
-  - `purl`  - package purl
-  - `pkgn`  - package name
-  - `pkgv`  - package version
-  - `pkgl`  - package licenses
+  - `docn` - sbom document name
+  - `docv` - sbom document version
+  - `cpe` - package cpe, only prints the first one, indicates how many cpe's exists.
+  - `purl` - package purl
+  - `pkgn` - package name
+  - `pkgv` - package version
+  - `pkgl` - package licenses
   - `specn` - spec of the sbom document, spdx or cdx.
-  - `chkn`  - checksum name
-  - `chkv`  - checksum value
-  - `repo`  - repository url
+  - `chkn` - checksum name
+  - `chkv` - checksum value
+  - `repo` - repository url
+  - `direct` - package is a direct dependency
 
-#### *Stats Control*
-----
+#### _Stats Control_
+
+---
+
 - `-c` or `--count` suppresses the normal output and print matching counts of sbom filenames and packages.
 
-#### *Directory Control*
-----
+#### _Directory Control_
+
+---
+
 - `-r` or `--recurse` when set, recursively scans all sub directories.
 
-#### *Spec Control*
-----
+#### _Spec Control_
+
+---
+
 - `--spdx` searches only files which are SPDX.
 - `--cdx` searches only files which are CycloneDX.
 
 # Future work
+
 - Search using files.
 - Search using tool metadata.
 - Search using CVE-ID.
@@ -225,6 +261,7 @@ all of these match criteria are exclusive to each other.
 - Provide a list of malicious packages
 
 # SBOM Samples
+
 - A sample set of SBOM is present in the [samples](https://github.com/interlynk-io/sbomgr/tree/main/samples) directory above.
 - [SBOM Benchmark](https://www.sbombenchmark.dev) is a repository of SBOM and quality score for most popular containers and repositories
 - [SBOM Explorer](https://github.com/interlynk-io/sbomex) is a command line utility to search and pull SBOMs
@@ -238,6 +275,7 @@ https://github.com/interlynk-io/sbomgr/releases
 ```
 
 ## Using Homebrew
+
 ```console
 brew tap interlynk-io/interlynk
 brew install sbomgr
@@ -258,8 +296,8 @@ This approach involves cloning the repo and building it.
 3. make build
 4. To test if the build was successful run the following command `./build/sbomgr version`
 
-
 # Contributions
+
 We look forward to your contributions, below are a few guidelines on how to submit them
 
 - Fork the repo
@@ -269,13 +307,16 @@ We look forward to your contributions, below are a few guidelines on how to subm
 - Create a new pull-request
 
 # Other SBOM Open Source tools
+
 - [SBOM Assembler](https://github.com/interlynk-io/sbomasm) - A tool to compose a single SBOM by combining other (part) SBOMs
 - [SBOM Quality Score](https://github.com/interlynk-io/sbomqs) - A tool for evaluating the quality and completeness of SBOMs
 - [SBOM Search Tool](https://github.com/interlynk-io/sbomagr) - A tool to grep style semantic search in SBOMs
 - [SBOM Explorer](https://github.com/interlynk-io/sbomex) - A tool for discovering and downloading SBOM from a public repository
 
 # Contact
+
 We appreciate all feedback. The best ways to get in touch with us:
+
 - :phone: [Live Chat](https://www.interlynk.io/#hs-chat-open)
 - 📫 [Email Us](mailto:hello@interlynk.io)
 - 🐛 [Report a bug or enhancement](https://github.com/interlynk-io/sbomex/issues)

--- a/pkg/search/cdx/results.go
+++ b/pkg/search/cdx/results.go
@@ -93,6 +93,12 @@ func (doc *cdxDoc) pkgResults(pIndices []int) []results.Package {
 			}
 		}
 
+		if doc.directComps != nil {
+			if _, ok := doc.directComps[comp.BOMRef]; ok {
+				res.Direct = true
+			}
+		}
+
 		if comp.Hashes != nil {
 			for _, c := range *comp.Hashes {
 				res.Checksums = append(res.Checksums, results.Checksum{

--- a/pkg/search/output.go
+++ b/pkg/search/output.go
@@ -25,20 +25,21 @@ import (
 )
 
 var OutputFormatOptions = map[string]bool{
-	"filen": true, //filename
-	"tooln": true, //toolname
-	"toolv": true, //toolversion
-	"docn":  true, //doc name
-	"docv":  true, //doc version
-	"cpe":   true, //cpe
-	"purl":  true, //purl
-	"pkgn":  true, //component name
-	"pkgv":  true, //component version
-	"pkgl":  true, //component license
-	"specn": true, //spec name
-	"chkn":  true, //checksum name
-	"chkv":  true, //checksum version
-	"repo":  true, //repository
+	"filen":  true, //filename
+	"tooln":  true, //toolname
+	"toolv":  true, //toolversion
+	"docn":   true, //doc name
+	"docv":   true, //doc version
+	"cpe":    true, //cpe
+	"purl":   true, //purl
+	"pkgn":   true, //component name
+	"pkgv":   true, //component version
+	"pkgl":   true, //component license
+	"specn":  true, //spec name
+	"chkn":   true, //checksum name
+	"chkv":   true, //checksum version
+	"repo":   true, //repository
+	"direct": true, //direct
 }
 
 func outputQuiet(r *results.Result, nr *SearchParams) (int, error) {
@@ -88,6 +89,8 @@ func outputJsonl(r *results.Result, nr *SearchParams) (int, error) {
 				newP.Checksums = p.Checksums
 			case "repo":
 				newP.Repository = p.Repository
+			case "direct":
+				newP.Direct = p.Direct
 			}
 		}
 		newPackages = append(newPackages, newP)
@@ -301,10 +304,16 @@ func customOutput(idx int, chkIdx int, r *results.Result, nr *SearchParams) []st
 				p = append(p, "[NOCHKV]")
 			}
 		case "repo":
-			if chkIdx >= 0 {
+			if len(pkg.Repository) > 0 {
 				p = append(p, pkg.Repository)
 			} else {
 				p = append(p, "[NOREPO]")
+			}
+		case "direct":
+			if pkg.Direct {
+				p = append(p, "Direct")
+			} else {
+				p = append(p, "[INDIRECT]")
 			}
 		}
 	}

--- a/pkg/search/spdx/results.go
+++ b/pkg/search/spdx/results.go
@@ -72,6 +72,12 @@ func (s *spdxDoc) pkgResults(indices []int) []results.Package {
 			pkgs[i].CPE = cpes
 		}
 
+		if s.directPkgs != nil {
+			if _, ok := s.directPkgs[string(s.doc.Packages[idx].PackageSPDXIdentifier)]; ok {
+				pkgs[i].Direct = true
+			}
+		}
+
 		for _, c := range s.doc.Packages[idx].PackageChecksums {
 			pkgs[i].Checksums = append(pkgs[i].Checksums, results.Checksum{
 				Algorithm: string(c.Algorithm),


### PR DESCRIPTION
Makes it easier to identify direct components. 



```
➜  sboms git:(main) ✗ ~/wrk/interlynk-io/sbomgr/build/sbomgr packages -O 'pkgn,pkgv,direct' demo-project-CycloneDX-report.json
zxing.net.bindings.skiasharp.0.16.13.nupkg                                      0.16.13                                         [INDIRECT]
system.io.filesystem.primitives.4.3.0.nupkg                                     4.3.0                                           [INDIRECT]
PrimaryApp                                                                      2.9.2                                           Direct
runtime.win7.system.private.uri.4.3.0.nupkg                                     4.3.0                                           Direct
```